### PR TITLE
Add tests demonstrating jackson serialization bug.

### DIFF
--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/GraphQLClientJacksonSerializerTest.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/GraphQLClientJacksonSerializerTest.kt
@@ -342,4 +342,36 @@ class GraphQLClientJacksonSerializerTest {
         val serialized = serializer.serialize(entitiesQuery)
         assertEquals(expected, serialized)
     }
+
+    @Test
+    fun `verify we can serialize is-prefixed variable fields`() {
+        val query = InputQuery(
+            variables = InputQuery.Variables(
+                // these 3 fields are required.
+                requiredInput = 1, nullableElementList = emptyList(), nonNullableElementList = emptyList(),
+                // test an is-prefixed field with a boolean value
+                isPrefixedBooleanField = true,
+                // test an is-prefixed field with a non-boolean value
+                isPrefixedNonBooleanField = InputQuery.BooleanFilter(equalTo = false)
+            )
+        )
+
+        val expected = """{
+            |  "variables" : {
+            |    "requiredInput" : 1,
+            |    "nullableElementList" : [ ],
+            |    "nonNullableElementList" : [ ],
+            |    "isPrefixedBooleanField" : true,
+            |    "isPrefixedNonBooleanField" : {
+            |      "equalTo" : false
+            |    }
+            |  },
+            |  "query" : "INPUT_QUERY",
+            |  "operationName" : "InputQuery"
+            |}
+        """.trimMargin()
+
+        val serialized = serializer.serialize(query)
+        assertEquals(expected, serialized)
+    }
 }

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/InputQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/InputQuery.kt
@@ -36,7 +36,13 @@ class InputQuery(
         val nullableListNullableElements: List<String?>? = null,
         val nullableListNonNullableElements: List<String>? = null,
         val nullableElementList: List<String?>,
-        val nonNullableElementList: List<String>
+        val nonNullableElementList: List<String>,
+        val isPrefixedBooleanField: Boolean? = null,
+        val isPrefixedNonBooleanField: BooleanFilter? = null
+    )
+
+    data class BooleanFilter(
+        val equalTo: Boolean
     )
 
     data class Result(

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/InputQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/InputQuery.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.client.jackson.data
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.fasterxml.jackson.annotation.JsonProperty
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -38,6 +39,7 @@ class InputQuery(
         val nullableElementList: List<String?>,
         val nonNullableElementList: List<String>,
         val isPrefixedBooleanField: Boolean? = null,
+        @JsonProperty("isPrefixedNonBooleanField")
         val isPrefixedNonBooleanField: BooleanFilter? = null
     )
 

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/GraphQLClientKotlinXSerializerTest.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/GraphQLClientKotlinXSerializerTest.kt
@@ -366,4 +366,39 @@ class GraphQLClientKotlinXSerializerTest {
         val serialized = serializer.serialize(entitiesQuery)
         assertEquals(expected, serialized)
     }
+
+
+    @Test
+    fun `verify we can serialize is-prefixed variable fields`() {
+        val query = InputQuery(
+            variables = InputQuery.Variables(
+                // these 3 fields are required.
+                requiredInput = 1, nullableElementList = emptyList(), nonNullableElementList = emptyList(),
+                // test an is-prefixed field with a boolean value
+                isPrefixedBooleanField = true,
+                // test an is-prefixed field with a non-boolean value
+                isPrefixedNonBooleanField = InputQuery.BooleanFilter(equalTo = false)
+            )
+        )
+
+        val expected = """{
+            |    "variables": {
+            |        "requiredInput": 1,
+            |        "nullableElementList": [
+            |        ],
+            |        "nonNullableElementList": [
+            |        ],
+            |        "isPrefixedBooleanField": true,
+            |        "isPrefixedNonBooleanField": {
+            |            "equalTo": false
+            |        }
+            |    },
+            |    "query": "INPUT_QUERY",
+            |    "operationName": "InputQuery"
+            |}
+        """.trimMargin()
+
+        val serialized = serializer.serialize(query)
+        assertEquals(expected, serialized)
+    }
 }

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/InputQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/InputQuery.kt
@@ -41,7 +41,14 @@ class InputQuery(
         val nullableListNullableElements: List<String?>? = null,
         val nullableListNonNullableElements: List<String>? = null,
         val nullableElementList: List<String?>,
-        val nonNullableElementList: List<String>
+        val nonNullableElementList: List<String>,
+        val isPrefixedBooleanField: Boolean? = null,
+        val isPrefixedNonBooleanField: BooleanFilter? = null
+    )
+
+    @Serializable
+    data class BooleanFilter(
+        val equalTo: Boolean
     )
 
     @Serializable


### PR DESCRIPTION
`GraphQLClientJacksonSerializer` has a bug related to is-prefixed variable input fields. If the is-prefixed field is a `Boolean` field it serializes correctly, but if the field type is not `Boolean`, then the Jackson serializer silently omits the field entirely.

I added a similar test for `GraphQLClientKotlinXSerializer` to demonstrate that the same bug does not exist on that serializer.
